### PR TITLE
Read values more efficiently

### DIFF
--- a/lib/SVN/Dump/Reader.pm
+++ b/lib/SVN/Dump/Reader.pm
@@ -133,18 +133,14 @@ sub read_property_block {
 
         # read a key/value pair
         if( $line =~ /\AK (\d+)\z/ ) {
-            my $key = '';
-            $key .= <$fh> while length($key) < $1;
-            chop $key; # remove the last $NL
+            my $key = $fh->_read_string( $1 );
 
             $line = <$fh>;
             croak _eof() if !defined $line;
             chop $line;
          
             if( $line =~ /\AV (\d+)\z/ ) {
-                my $value = '';
-                $value .= <$fh> while length($value) <= $1;
-                chop $value; # remove the last $NL
+                my $value = $fh->_read_string( $1 );
 
                 $property->set( $key => $value );
 
@@ -157,9 +153,7 @@ sub read_property_block {
         # or a deleted key (only with fs-format-version >= 3)
         # FIXME shall we fail if fs-format-version < 3?
         elsif( $line =~ /\AD (\d+)\z/ ) {
-            my $key = '';
-            $key .= <$fh> while length($key) < $1;
-            chop $key; # remove the last $NL
+            my $key = $fh->_read_string( $1 );
             
             $property->set( $key => undef ); # undef means deleted
         }
@@ -179,20 +173,31 @@ sub read_property_block {
 sub read_text_block {
     my ($fh, $size) = @_;
 
+    return SVN::Dump::Text->new( $fh->_read_string( $size ) );
+}
+
+sub _read_string {
+
+    my ( $fh, $size ) = @_;
+
     local $/ = $NL;
 
-    my $text = '';
-    while( length($text) <= $size ) {
-        my $line = <$fh>;
-        croak _eof() if ! defined $line;
-        $text .= $line;
-    }
+    my $text;
+    my $characters_read = read( $fh, $text, $size );
 
-    # remove extra $NL
-    chop $text while length($text) > $size;
+    if ( defined($characters_read) ) {
+        if ( $characters_read != $size ) {
+            croak _eof();
+        };
+    } else {
+        croak $!;
+    };
 
-    return SVN::Dump::Text->new( $text );
-}
+    <$fh>; # clear trailing newline
+
+    return $text;
+
+};
 
 # FIXME make this more explicit
 sub _eof { return "Unexpected EOF line $.", }


### PR DESCRIPTION
Testing with NYTProf shows the library spends most of its time reading strings.
This patch would replace all fixed-length read operations with a new ->_read_string(), which
in turn calls read() for a big speed boost.
