### PR TITLE
Use open with 3 args, and don't complain about the filehandle in perl <5.20

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for SVN-Dump
 
 {{$NEXT}}
 
+0.09 2024-07-28 ELBEHO
+    - Better filehandle detection in SVN::Dump::Reader, now works on older version of Perl
+    - Use open with 3 args in SVN::Dump
+
 0.08 2020-03-02 BOOK
     - Make SVN::Dump::Reader more liberal in what it accepts for 'fh' - RT #24032
 

--- a/lib/SVN/Dump.pm
+++ b/lib/SVN/Dump.pm
@@ -18,7 +18,11 @@ sub new {
     if ( exists $args->{fh} || exists $args->{file} ) {
         my ( $fh, $file ) = delete @{$args}{qw( fh file )};
         if ( !$fh ) {
-            open $fh, $file or croak "Can't open $file: $!";
+            if ( $file eq '-' ) {
+                open $fh, '<-' or croak "Can't open STDIN: $!";
+            } else {
+                open $fh, '<', $file or croak "Can't open $file: $!";
+            }
         }
         $self->{reader} = SVN::Dump::Reader->new( $fh, $args );
     }

--- a/lib/SVN/Dump/Reader.pm
+++ b/lib/SVN/Dump/Reader.pm
@@ -25,7 +25,7 @@ my @digest = grep {
 sub new {
     my ($class, $fh, $args) = @_;
     croak 'SVN::Dump::Reader parameter is not a filehandle'
-      unless eval { $fh && ref $fh && $fh->can('getline') && $fh->can('read') };
+      unless eval { $fh && ref $fh && $fh->opened };
     %{*$fh} = %{ $args || {} };
     return bless $fh, $class;
 }


### PR DESCRIPTION
I ran the tests using docker on the latest images of perl 5.10, 5.12, 5.14... 5.40
